### PR TITLE
Add asynchronous tool wrappers and await tools endpoint

### DIFF
--- a/src/azure_sharepoint_mcp/server.py
+++ b/src/azure_sharepoint_mcp/server.py
@@ -12,6 +12,9 @@ from mcp.types import (
     TextContent,
     ImageContent,
     EmbeddedResource,
+    ListToolsRequest,
+    CallToolRequest,
+    CallToolRequestParams,
 )
 from pydantic import BaseModel
 
@@ -53,7 +56,7 @@ class SharePointMCPServer:
         
         # Register handlers
         self._register_handlers()
-    
+
     def _register_handlers(self) -> None:
         """Register MCP handlers."""
         
@@ -72,7 +75,7 @@ class SharePointMCPServer:
         @self.server.read_resource()
         async def handle_read_resource(uri: str) -> str:
             """Read SharePoint resource."""
-            if uri == "sharepoint://files":
+            if str(uri) == "sharepoint://files":
                 try:
                     files = self.client.list_files("/")
                     return json.dumps(files, indent=2)
@@ -276,6 +279,21 @@ class SharePointMCPServer:
             except Exception as e:
                 logger.error(f"Tool '{name}' failed: {e}")
                 return [TextContent(type="text", text=json.dumps({"error": str(e)}))]
+
+    async def list_tools(self) -> List[Tool]:
+        """List registered MCP tools."""
+        req = ListToolsRequest(method="tools/list")
+        result = await self.server.request_handlers[ListToolsRequest](req)
+        return result.root.tools
+
+    async def call_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Call a registered tool by name."""
+        req = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name=name, arguments=arguments),
+        )
+        result = await self.server.request_handlers[CallToolRequest](req)
+        return result.root.content
     
     async def run(self, transport_type: str = "stdio") -> None:
         """Run the MCP server.

--- a/src/azure_sharepoint_mcp/web_server.py
+++ b/src/azure_sharepoint_mcp/web_server.py
@@ -73,7 +73,8 @@ async def health():
 async def tools():
     """List available MCP tools."""
     if mcp_server:
-        return {"tools": [tool.name for tool in mcp_server.list_tools()]}
+        tools = await mcp_server.list_tools()
+        return {"tools": [tool.name for tool in tools]}
     return {"tools": ["list_files", "read_file", "write_file", "delete_file", "create_folder", "get_site_info"]}
 
 @app.post("/execute")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 
 import pytest
 from unittest.mock import Mock, patch
+from mcp import types as mcp_types
 from azure_sharepoint_mcp import SharePointMCPServer, SharePointConfig
 
 
@@ -32,29 +33,31 @@ def test_server_initialization(server, config):
 @pytest.mark.asyncio
 async def test_list_resources(server):
     """Test listing resources."""
-    resources = await server.server.list_resources()()
-    
+    req = mcp_types.ListResourcesRequest(method="resources/list")
+    result = await server.server.request_handlers[mcp_types.ListResourcesRequest](req)
+    resources = result.root.resources
+
     assert len(resources) == 1
-    assert resources[0].uri == "sharepoint://files"
+    assert str(resources[0].uri) == "sharepoint://files"
     assert resources[0].name == "SharePoint Files"
 
 
 @pytest.mark.asyncio
 async def test_list_tools(server):
     """Test listing tools."""
-    tools = await server.server.list_tools()()
-    
+    tools = await server.list_tools()
+
     tool_names = [tool.name for tool in tools]
     expected_tools = [
         "list_files",
-        "read_file", 
+        "read_file",
         "write_file",
         "delete_file",
         "create_folder",
         "file_exists",
         "test_connection"
     ]
-    
+
     for expected_tool in expected_tools:
         assert expected_tool in tool_names
 
@@ -66,16 +69,24 @@ async def test_read_resource_files(server):
         mock_list.return_value = [
             {"name": "test.txt", "type": "file", "path": "/test.txt"}
         ]
-        
-        result = await server.server.read_resource()("sharepoint://files")
-        assert "test.txt" in result
+
+        req = mcp_types.ReadResourceRequest(
+            method="resources/read",
+            params=mcp_types.ReadResourceRequestParams(uri="sharepoint://files"),
+        )
+        result = await server.server.request_handlers[mcp_types.ReadResourceRequest](req)
+        assert "test.txt" in result.root.contents[0].text
 
 
 @pytest.mark.asyncio
 async def test_read_resource_unknown(server):
     """Test reading unknown resource."""
-    result = await server.server.read_resource()("unknown://resource")
-    assert "error" in result.lower()
+    req = mcp_types.ReadResourceRequest(
+        method="resources/read",
+        params=mcp_types.ReadResourceRequestParams(uri="unknown://resource"),
+    )
+    result = await server.server.request_handlers[mcp_types.ReadResourceRequest](req)
+    assert "error" in result.root.contents[0].text.lower()
 
 
 @pytest.mark.asyncio
@@ -85,8 +96,8 @@ async def test_call_tool_list_files(server):
         mock_list.return_value = [
             {"name": "test.txt", "type": "file", "path": "/test.txt"}
         ]
-        
-        result = await server.server.call_tool()("list_files", {"folder_path": "/"})
+
+        result = await server.call_tool("list_files", {"folder_path": "/"})
         assert len(result) == 1
         assert "test.txt" in result[0].text
 
@@ -97,7 +108,7 @@ async def test_call_tool_test_connection(server):
     with patch.object(server.authenticator, 'test_connection') as mock_test:
         mock_test.return_value = True
         
-        result = await server.server.call_tool()("test_connection", {})
+        result = await server.call_tool("test_connection", {})
         assert len(result) == 1
         assert "connected" in result[0].text.lower()
 
@@ -105,6 +116,6 @@ async def test_call_tool_test_connection(server):
 @pytest.mark.asyncio
 async def test_call_tool_unknown(server):
     """Test unknown tool."""
-    result = await server.server.call_tool()("unknown_tool", {})
+    result = await server.call_tool("unknown_tool", {})
     assert len(result) == 1
     assert "unknown tool" in result[0].text.lower()


### PR DESCRIPTION
## Summary
- add async `list_tools` and `call_tool` wrappers to SharePointMCPServer
- await MCP server in `/tools` endpoint to return tool names
- expand server tests for wrappers and request handlers

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae376fc0b483308ef3e2083dd34f75