### PR TITLE
Fix config argument names in web server

### DIFF
--- a/src/azure_sharepoint_mcp/web_server.py
+++ b/src/azure_sharepoint_mcp/web_server.py
@@ -39,10 +39,10 @@ def initialize_mcp_server():
     global mcp_server
     try:
         config = SharePointConfig(
-            sharepoint_site_url=os.getenv("SHAREPOINT_SITE_URL"),
-            azure_tenant_id=os.getenv("AZURE_TENANT_ID"),
-            azure_client_id=os.getenv("AZURE_CLIENT_ID"),
-            azure_client_secret=os.getenv("AZURE_CLIENT_SECRET")
+            site_url=os.getenv("SHAREPOINT_SITE_URL"),
+            tenant_id=os.getenv("AZURE_TENANT_ID"),
+            client_id=os.getenv("AZURE_CLIENT_ID"),
+            client_secret=os.getenv("AZURE_CLIENT_SECRET"),
         )
         mcp_server = SharePointMCPServer(config)
         logger.info("MCP Server initialized successfully")


### PR DESCRIPTION
## Summary
- Use correct SharePoint configuration argument names in `initialize_mcp_server`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'azure_sharepoint_mcp')*

------
https://chatgpt.com/codex/tasks/task_b_68ae376d91d4833094995776d14670fa