### PR TITLE
refactor: add sync main wrapper

### DIFF
--- a/src/azure_sharepoint_mcp/server.py
+++ b/src/azure_sharepoint_mcp/server.py
@@ -319,10 +319,10 @@ class SharePointMCPServer:
             raise ValueError(f"Unsupported transport type: {transport_type}")
 
 
-async def main() -> None:
+async def async_main() -> None:
     """Main entry point."""
     import os
-    
+
     # Load configuration from environment variables
     config = SharePointConfig(
         site_url=os.getenv("SHAREPOINT_SITE_URL", ""),
@@ -330,13 +330,17 @@ async def main() -> None:
         client_id=os.getenv("AZURE_CLIENT_ID"),
         client_secret=os.getenv("AZURE_CLIENT_SECRET"),
     )
-    
+
     if not config.site_url:
         raise ValueError("SHAREPOINT_SITE_URL environment variable is required")
-    
+
     server = SharePointMCPServer(config)
     await server.run()
 
 
+def main() -> None:
+    asyncio.run(async_main())
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary
- expose new async_main coroutine and synchronous main wrapper

## Testing
- `PYTHONPATH=src pytest -q` *(fails: AssertionError and TypeError)*

------
https://chatgpt.com/codex/tasks/task_b_68ae7de5efe483308daf9fb00cea25aa