### PR TITLE
Ensure full path returned and use replace conflict behavior

### DIFF
--- a/src/azure_sharepoint_mcp/graph_client.py
+++ b/src/azure_sharepoint_mcp/graph_client.py
@@ -173,7 +173,7 @@ class GraphSharePointClient:
             overwrite: Whether to overwrite existing file. When ``False``,
                 the method checks if the file already exists and raises an
                 exception if it does. The upload request sets the
-                ``@microsoft.graph.conflictBehavior`` header to ``"rename"``
+                ``@microsoft.graph.conflictBehavior`` header to ``"replace"``
                 when overwriting and ``"fail"`` otherwise.
 
         Returns:
@@ -201,7 +201,7 @@ class GraphSharePointClient:
             headers = self._get_headers()
             headers["Content-Type"] = "application/octet-stream"
             headers["@microsoft.graph.conflictBehavior"] = (
-                "rename" if overwrite else "fail"
+                "replace" if overwrite else "fail"
             )
 
             response = requests.put(url, headers=headers, data=content_bytes)
@@ -211,7 +211,7 @@ class GraphSharePointClient:
             
             return {
                 "name": file_data["name"],
-                "path": f"/{file_data['name']}",
+                "path": f"/{clean_path}",
                 "size": file_data["size"],
                 "modified": file_data.get("lastModifiedDateTime"),
                 "created": file_data.get("createdDateTime"),

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from azure_sharepoint_mcp.graph_client import GraphSharePointClient
+
+
+def _make_client():
+    auth = Mock()
+    auth.get_graph_token.return_value = "token"
+    auth.site_url = "https://test.sharepoint.com/sites/test"
+    client = GraphSharePointClient(auth)
+    client._get_default_drive_id = Mock(return_value="drive123")
+    client.file_exists = Mock(return_value=False)
+    return client
+
+
+def test_write_file_overwrite_replace_and_path():
+    client = _make_client()
+    captured_headers = {}
+
+    def mock_put(url, headers=None, data=None):
+        captured_headers.update(headers)
+        response = Mock()
+        response.raise_for_status = Mock()
+        response.json.return_value = {
+            "name": "file.txt",
+            "size": 4,
+            "id": "1"
+        }
+        return response
+
+    with patch("requests.put", side_effect=mock_put):
+        result = client.write_file("/folder/file.txt", b"data", overwrite=True)
+
+    assert captured_headers["@microsoft.graph.conflictBehavior"] == "replace"
+    assert result["path"] == "/folder/file.txt"
+
+
+def test_write_file_no_overwrite_fail_and_path():
+    client = _make_client()
+    captured_headers = {}
+
+    def mock_put(url, headers=None, data=None):
+        captured_headers.update(headers)
+        response = Mock()
+        response.raise_for_status = Mock()
+        response.json.return_value = {
+            "name": "file2.txt",
+            "size": 4,
+            "id": "2"
+        }
+        return response
+
+    with patch("requests.put", side_effect=mock_put):
+        result = client.write_file("/file2.txt", b"data", overwrite=False)
+
+    assert captured_headers["@microsoft.graph.conflictBehavior"] == "fail"
+    assert result["path"] == "/file2.txt"


### PR DESCRIPTION
## Summary
- use `replace` for `@microsoft.graph.conflictBehavior` when overwriting files
- return the full file path in write file metadata
- test overwrite conflict behavior and path handling

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae84c708e083308c9d0826a41110af