### PR TITLE
Serialize MCP tool results for FastAPI responses

### DIFF
--- a/src/azure_sharepoint_mcp/web_server.py
+++ b/src/azure_sharepoint_mcp/web_server.py
@@ -85,7 +85,8 @@ async def execute_tool(tool_name: str, params: Dict[str, Any] = None):
     
     try:
         result = await mcp_server.call_tool(tool_name, params or {})
-        return {"success": True, "result": result}
+        serialized = [c.model_dump() if isinstance(c, BaseModel) else c for c in result]
+        return {"success": True, "result": serialized}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -97,7 +98,8 @@ async def get_site_info():
     
     try:
         result = await mcp_server.call_tool("get_site_info", {})
-        return {"success": True, "result": result}
+        serialized = [c.model_dump() if isinstance(c, BaseModel) else c for c in result]
+        return {"success": True, "result": serialized}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -109,7 +111,8 @@ async def list_files():
     
     try:
         result = await mcp_server.call_tool("list_files", {})
-        return {"success": True, "result": result}
+        serialized = [c.model_dump() if isinstance(c, BaseModel) else c for c in result]
+        return {"success": True, "result": serialized}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,0 +1,26 @@
+import pytest
+from fastapi.testclient import TestClient
+from mcp.types import TextContent
+from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+
+from azure_sharepoint_mcp import web_server
+
+
+def mock_init(mock_server):
+    def _init():
+        web_server.mcp_server = mock_server
+    return _init
+
+
+def test_execute_returns_json():
+    mock_server = SimpleNamespace()
+    mock_server.call_tool = AsyncMock(return_value=[TextContent(type="text", text="hello")])
+
+    with patch("azure_sharepoint_mcp.web_server.initialize_mcp_server", mock_init(mock_server)):
+        with TestClient(web_server.app) as client:
+            response = client.post("/execute", params={"tool_name": "test"}, json={"params": {}})
+            assert response.status_code == 200
+            data = response.json()
+            assert data["result"][0]["type"] == "text"
+            assert data["result"][0]["text"] == "hello"


### PR DESCRIPTION
## Summary
- Serialize `TextContent` objects in web server endpoints to ensure JSON responses
- Add unit test verifying `/execute` endpoint returns JSON-friendly data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae85e25d888330b05ad27d797d92de